### PR TITLE
Remove `?src=donate` from download URLs

### DIFF
--- a/sites/all/modules/custom/cividownload/cividownload.tpl.php
+++ b/sites/all/modules/custom/cividownload/cividownload.tpl.php
@@ -16,7 +16,7 @@
 	  		<li><?php
         $url = $values['url'];
         if (arg(1) == 'list' && variable_get('cividownload_mode') == 2 ) {
-          $url = "https://download.civicrm.org/civicrm-{$content['civicrm_version']}-" . $values['filename'] . "?src=donate";
+          $url = "https://download.civicrm.org/civicrm-{$content['civicrm_version']}-" . $values['filename'];
         }
         ?>
         <a href="<?php echo $url;?>" target="_blank">Download CiviCRM <?php echo $content['civicrm_version']; ?> <?php echo $values['title']; ?></a></li>


### PR DESCRIPTION
Currently this does nothing AFAIK to improve tracking (we act as if *all* links come from "download" or something), but interferes with the URLs when used on CLI, because

* `?` has a special meaning in CLI so copying the URL then requires either escaping, wrapping in quote marks, or removing the `?src=donate` suffix, AND
* the resulting filename by default is `civicrm-4.7.19-drupal.tar.gz?src=donate`

Let's remove that, it's just noise IMO. (If there's a reason for that to be there, happy to help get rid of it in a way that retains existing functionality relating to same.)